### PR TITLE
Clean up requirements.txt by removing standard library modules

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,1 @@
 pillow
-shutil
-zipfile
-time
-argparse
-subprocess


### PR DESCRIPTION
Removed "shutil", "zipfile", "time", "argparse", and "subprocess" from the requirements.txt file as they are part of the Python standard library and do not need to be installed via pip.  This cleanup helps avoid installation errors related to attempting to install these standard modules and ensures only external dependencies, such as "pillow", are specified. This change streamlines project setup and dependency installation.